### PR TITLE
Update CuP main repo link to public link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CuP Template project
 
-This project is a template for a [Compose ur Pres](https://github.com/kosi-libs/CuP) project.
+This project is a template for a [Compose ur Pres](https://github.com/KodeinKoders/CuP) project.
 
 1. Edit [settings.gradle.kts](settings.gradle.kts):
     - Change the name of your project (which will define the package of the compose Res class).


### PR DESCRIPTION
The link to the main CuP repo within the template README is incorrect

This now points to https://github.com/KodeinKoders/CuP